### PR TITLE
Add loading state to compose form + clean up

### DIFF
--- a/web/src/screens/compose/components/ComposeForm/ComposeForm.tsx
+++ b/web/src/screens/compose/components/ComposeForm/ComposeForm.tsx
@@ -38,7 +38,7 @@ export function ComposeForm(props: Props) {
             <Button
               variant="ghost"
               size="xs"
-              disabled={!form.formState.isValid}
+              disabled={!form.formState.isValid || state.isSavingDraft}
               onClick={handlers.handleSaveDraft}
               loading={state.isSavingDraft}
             >
@@ -49,7 +49,7 @@ export function ComposeForm(props: Props) {
               variant="subtle"
               size="xs"
               type="submit"
-              disabled={!form.formState.isValid}
+              disabled={!form.formState.isValid || state.isPublishing}
               loading={state.isPublishing}
             >
               Post

--- a/web/src/screens/compose/components/ComposeForm/ComposeForm.tsx
+++ b/web/src/screens/compose/components/ComposeForm/ComposeForm.tsx
@@ -11,8 +11,7 @@ import { TitleInput } from "../TitleInput/TitleInput";
 import { Props, useComposeForm } from "./useComposeForm";
 
 export function ComposeForm(props: Props) {
-  const { formContext, onPublish, onSave, onAssetUpload } =
-    useComposeForm(props);
+  const { form, state, handlers } = useComposeForm(props);
 
   return (
     <styled.form
@@ -22,15 +21,15 @@ export function ComposeForm(props: Props) {
       w="full"
       h="full"
       gap="2"
-      onSubmit={onPublish}
+      onSubmit={handlers.handlePublish}
     >
-      <FormProvider {...formContext}>
+      <FormProvider {...form}>
         <WStack>
           <HStack width="full">
             <CategorySelect />
             <TagListField
               name="tags"
-              control={formContext.control}
+              control={form.control}
               initialTags={props.initialDraft?.tags}
             />
           </HStack>
@@ -39,8 +38,9 @@ export function ComposeForm(props: Props) {
             <Button
               variant="ghost"
               size="xs"
-              disabled={!formContext.formState.isValid}
-              onClick={onSave}
+              disabled={!form.formState.isValid}
+              onClick={handlers.handleSaveDraft}
+              loading={state.isSavingDraft}
             >
               Save draft
             </Button>
@@ -49,8 +49,8 @@ export function ComposeForm(props: Props) {
               variant="subtle"
               size="xs"
               type="submit"
-              disabled={!formContext.formState.isValid}
-              // isLoading={formContext.formState.isSubmitting}
+              disabled={!form.formState.isValid}
+              loading={state.isPublishing}
             >
               Post
             </Button>
@@ -63,7 +63,7 @@ export function ComposeForm(props: Props) {
           </HStack>
         </HStack>
 
-        <BodyInput onAssetUpload={onAssetUpload} />
+        <BodyInput onAssetUpload={handlers.handleAssetUpload} />
       </FormProvider>
     </styled.form>
   );

--- a/web/src/screens/compose/components/ComposeForm/useComposeForm.ts
+++ b/web/src/screens/compose/components/ComposeForm/useComposeForm.ts
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
+import { useState } from "react";
 import { z } from "zod";
 
 import { useCategoryList } from "src/api/openapi-client/categories";
@@ -23,8 +24,11 @@ export type FormShape = z.infer<typeof FormShapeSchema>;
 export function useComposeForm({ initialDraft, editing }: Props) {
   const router = useRouter();
 
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [isSavingDraft, setIsSavingDraft] = useState(false);
+
   const { data } = useCategoryList();
-  const formContext = useForm<FormShape>({
+  const form = useForm<FormShape>({
     resolver: zodResolver(FormShapeSchema),
     reValidateMode: "onChange",
     defaultValues: initialDraft
@@ -40,7 +44,7 @@ export function useComposeForm({ initialDraft, editing }: Props) {
         },
   });
 
-  const doSave = async (data: FormShape) => {
+  const saveDraft = async (data: FormShape) => {
     const payload: ThreadInitialProps = {
       ...data,
 
@@ -57,78 +61,118 @@ export function useComposeForm({ initialDraft, editing }: Props) {
       await threadUpdate(editing, payload);
     } else {
       const { id } = await threadCreate(payload);
-
       router.push(`/new?id=${id}`);
     }
-  };
+  }
 
-  const doPublish = async ({ title, body, category, tags, url }: FormShape) => {
+  const publish = async ({ title, body, category, tags, url }: FormShape) => {
     if (title.length < 1) {
-      formContext.setError("title", {
+      form.setError("title", {
         message: "Your post must have a title to be published",
       });
       return;
     }
 
+    const updatedBody = {
+      title,
+      body,
+      category,
+      visibility: Visibility.published,
+      tags,
+      url,
+    };
     if (editing) {
-      const { slug } = await threadUpdate(editing, {
-        title,
-        body,
-        category,
-        visibility: Visibility.published,
-        tags,
-        url,
-      });
+      const { slug } = await threadUpdate(editing, updatedBody);
       router.push(`/t/${slug}`);
     } else {
-      const { slug } = await threadCreate({
-        title,
-        body,
-        category,
-        visibility: Visibility.published,
-        tags,
-        url,
-      });
+      const { slug } = await threadCreate(updatedBody);
       router.push(`/t/${slug}`);
     }
   };
 
-  const onAssetUpload = async () => {
-    const state = formContext.getValues();
-    await handle(async () => {
-      await doSave(state);
-    });
+  const handleSaveDraft = form.handleSubmit((data) =>
+    handle(
+      async () => {
+        setIsSavingDraft(true);
+        await saveDraft(data);
+      },
+      {
+        promiseToast: {
+          loading: "Saving draft...",
+          success: "Draft saved!"
+        },
+        cleanup: async () => {
+          setIsSavingDraft(false);
+        }
+      }
+  ));
+
+  const handlePublish = form.handleSubmit((data) =>
+    handle(
+      async () => {
+        setIsPublishing(true);
+        await publish(data);
+      },
+      {
+        promiseToast: {
+          loading: "Publishing post...",
+          success: "Post published!"
+        },
+        cleanup: async () => {
+          setIsPublishing(false);
+        }
+      }
+  ));
+
+  const handleAssetUpload = async () => {
+    await handle(
+      async () => {
+        setIsSavingDraft(true);
+        const state = form.getValues();
+        await saveDraft(state);
+      },
+      {
+        promiseToast: {
+          loading: "Saving draft...",
+          success: "Draft saved!"
+        },
+        cleanup: async () => {
+          setIsSavingDraft(false);
+        }
+      }
+    );
   };
 
-  const onAssetDelete = async () => {
-    const state = formContext.getValues();
-    await handle(async () => {
-      await doSave(state);
-    });
+  const handleAssetDelete = async () => {
+    await handle(
+      async () => {
+        setIsSavingDraft(true);
+        const state = form.getValues();
+        await saveDraft(state);
+      },
+      {
+        promiseToast: {
+          loading: "Saving draft...",
+          success: "Draft saved!"
+        },
+        cleanup: async () => {
+          setIsSavingDraft(false);
+        }
+      }
+    );
   };
-
-  function onBack() {
-    router.back();
-  }
-
-  const onSave = formContext.handleSubmit((data) =>
-    handle(async () => {
-      await doSave(data);
-    }),
-  );
-
-  const onPublish = formContext.handleSubmit((data) =>
-    handle(async () => {
-      await doPublish(data);
-    }),
-  );
 
   return {
-    onBack,
-    onSave,
-    onPublish,
-    onAssetUpload,
-    onAssetDelete,
-    formContext,
+    form,
+    state: {
+      isPublishing,
+      isSavingDraft
+    },
+    handlers: {
+      handleSaveDraft,
+      handlePublish,
+      handleAssetDelete,
+      handleAssetUpload
+    }
   };
 }


### PR DESCRIPTION
Work-in-progress draft PR to:
- Add loading states to the Save Draft and Publish buttons on a thread compose
- Update handlers to use the `handleX` naming scheme rather than `onX`
- Wrap handlers in `handle()` with a toast and loading state
- Clean up export structure to generally match other similar files

This PR won't be merged here in this fork, and is just to track our work.